### PR TITLE
Chat async

### DIFF
--- a/src/components/chat/Chat.js
+++ b/src/components/chat/Chat.js
@@ -24,7 +24,7 @@ class Chat extends React.Component {
 
     async componentDidMount() {
          try {
-            let requestHeader = 'X-Auth-Token ' + localStorage.getItem('token');
+            let requestHeader = 'X-Auth-Token ' + sessionStorage.getItem('token');
             let response = await api.get(`chat/${this.props.chatEndpoint}`, {headers: {'X-Auth-Token': requestHeader}});
             this.setState({
                 messages: response.data,
@@ -52,7 +52,7 @@ class Chat extends React.Component {
         }
         this.setState({asyncLock: true})
         try {
-            let requestHeader = 'X-Auth-Token ' + localStorage.getItem('token');
+            let requestHeader = 'X-Auth-Token ' + sessionStorage.getItem('token');
             let response = await api.get(`chatpoll/${this.props.chatEndpoint}`, {headers: {'X-Auth-Token': requestHeader}});
             this.setState({
                 messages: response.data,

--- a/src/components/chat/ChatInput.js
+++ b/src/components/chat/ChatInput.js
@@ -32,13 +32,24 @@ export function ChatInput(props) {
 
 async function submitMessage(chatEndpoint, message) {
 
+    let requestHeader = 'X-Auth-Token ' + localStorage.getItem('token');
+    let username = ''
+    try {
+        let response = await api.get(`user` + '/' + localStorage.getItem('userId'), {headers: {'X-Auth-Token': requestHeader}});
+        username = response.data.username
+    }
+    catch (error) {
+        alert(`An error occurred when retrieving the user name: ${handleError(error)}`);
+    }
+
     let requestBody = JSON.stringify({
+        username: username,
         message: message
     });
 
     try {
         let requestHeader = 'X-Auth-Token ' + localStorage.getItem('token');
-        await api.put(`${chatEndpoint}`, requestBody, {headers: {'X-Auth-Token': requestHeader}});
+        await api.post(`chat/${chatEndpoint}`, requestBody, {headers: {'X-Auth-Token': requestHeader}});
         document.getElementById('chatInput').value = ''; // clear message after successful submission
     }
     catch (error) {

--- a/src/components/chat/ChatInput.js
+++ b/src/components/chat/ChatInput.js
@@ -32,10 +32,10 @@ export function ChatInput(props) {
 
 async function submitMessage(chatEndpoint, message) {
 
-    let requestHeader = 'X-Auth-Token ' + localStorage.getItem('token');
+    let requestHeader = 'X-Auth-Token ' + sessionStorage.getItem('token');
     let username = ''
     try {
-        let response = await api.get(`user` + '/' + localStorage.getItem('userId'), {headers: {'X-Auth-Token': requestHeader}});
+        let response = await api.get(`user` + '/' + sessionStorage.getItem('userId'), {headers: {'X-Auth-Token': requestHeader}});
         username = response.data.username
     }
     catch (error) {
@@ -48,7 +48,7 @@ async function submitMessage(chatEndpoint, message) {
     });
 
     try {
-        let requestHeader = 'X-Auth-Token ' + localStorage.getItem('token');
+        let requestHeader = 'X-Auth-Token ' + sessionStorage.getItem('token');
         await api.post(`chat/${chatEndpoint}`, requestBody, {headers: {'X-Auth-Token': requestHeader}});
         document.getElementById('chatInput').value = ''; // clear message after successful submission
     }

--- a/src/components/lobby/Lobby.js
+++ b/src/components/lobby/Lobby.js
@@ -197,7 +197,7 @@ export class Lobby extends React.Component {
                     <ChatButton/>
                 </BottomLeftContainer>
                 <ChatContainer style={{gridArea: "1 / 1 / 3 / 2"}}>
-                    <Chat chatEndpoint={`/lobby/${localStorage.getItem('lobbyId')}/chat`}/>
+                    <Chat chatEndpoint={`${localStorage.getItem('lobbyId')}`}/>
                 </ChatContainer>
                 <CenterContainer>
                     <ActionContainer>

--- a/src/components/lobby/Lobby.js
+++ b/src/components/lobby/Lobby.js
@@ -86,7 +86,7 @@ export class Lobby extends React.Component {
             alert(`Something went wrong while fetching the users: ${error}`);
         }
         this.setState({loaded: true});
-        api.post(`/lobbypoll/${localStorage.getItem('lobbyId')}`, {headers: {'X-Auth-Token': requestHeader}});
+        api.post(`/lobbypoll/${sessionStorage.getItem('lobbyId')}`, {headers: {'X-Auth-Token': requestHeader}});
         this.updateLobby()
         this.setState({updateTimer: setInterval(() => this.updateLobby(), 1000)})
     }
@@ -113,9 +113,9 @@ export class Lobby extends React.Component {
     }
 
     leaveLobby = async () => {
-        let requestHeader = 'X-Auth-Token ' + localStorage.getItem('token');
-        await api.delete(`lobby/${localStorage.getItem('lobbyId')}`,
-            {headers: {'X-Auth-Token': requestHeader}, data: localStorage.getItem('userId'), params:{browserClose:false}})
+        let requestHeader = 'X-Auth-Token ' + sessionStorage.getItem('token');
+        await api.delete(`lobby/${sessionStorage.getItem('lobbyId')}`,
+            {headers: {'X-Auth-Token': requestHeader}, data: sessionStorage.getItem('userId'), params:{browserClose:false}})
             .then(r => {
                 sessionStorage.removeItem("lobbyId");
                 this.props.history.push(`/mainpage`);
@@ -131,7 +131,7 @@ export class Lobby extends React.Component {
         }
         // set the asyncLock, don't forget to reset in the return scenarios.
         this.setState({asyncLock: true});
-        if(!localStorage.getItem("lobbyId")){
+        if(!sessionStorage.getItem("lobbyId")){
             return;
         }
       
@@ -149,7 +149,7 @@ export class Lobby extends React.Component {
         }
 
         try {
-            const response = await api.get(`/lobbypoll/${localStorage.getItem('lobbyId')}`, {headers: {'X-Auth-Token': requestHeader}});
+            const response = await api.get(`/lobbypoll/${sessionStorage.getItem('lobbyId')}`, {headers: {'X-Auth-Token': requestHeader}});
             if (response.data == null) {
                 this.setState({asyncLock: false});
                 this.updateLobby();
@@ -197,7 +197,7 @@ export class Lobby extends React.Component {
                     <ChatButton/>
                 </BottomLeftContainer>
                 <ChatContainer style={{gridArea: "1 / 1 / 3 / 2"}}>
-                    <Chat chatEndpoint={`${localStorage.getItem('lobbyId')}`}/>
+                    <Chat chatEndpoint={`${sessionStorage.getItem('lobbyId')}`}/>
                 </ChatContainer>
                 <CenterContainer>
                     <ActionContainer>

--- a/src/components/mainpage/MainPage.js
+++ b/src/components/mainpage/MainPage.js
@@ -73,7 +73,7 @@ export class MainPage extends React.Component {
                     <LogoutButton history={this.props.history}/>
                 </ TopLeftContainer>
                 <ChatContainer>
-                    <Chat chatEndpoint={'/chat'}/>
+                    <Chat chatEndpoint={'1'}/>
                 </ChatContainer>
                 <BottomLeftContainer>
                     <ChatButton/>


### PR DESCRIPTION
This implements the chat functionality as another asynchronous service using long polling.
I also changed the chat api. There is now a separate /chat endpoint that can take chat ids as a parameter. The /chat/1 is always there, while /chat/n are created with the same as id as the lobby when a new lobby is created.