### PR TITLE
Fixup not matching message whitespace overlap

### DIFF
--- a/src/components/registration/Registration.js
+++ b/src/components/registration/Registration.js
@@ -138,6 +138,7 @@ float:left;
 height: 38px;
 margin-left: 5px;
 margin-top: 2px;
+white-space: nowrap;
 display:none;
 width:fit-content;
 padding:1%;


### PR DESCRIPTION
The Not Matching message shown when inputting a password on the registration screen was rendering overlapping text.