### PR TITLE
number of skipped words in the game info

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -2765,3 +2765,4 @@
 [0517/131822.115:ERROR:crash_report_database_win.cc(469)] failed to stat report
 [0517/131822.115:ERROR:crash_report_database_win.cc(469)] failed to stat report
 [0517/131822.115:ERROR:crash_report_database_win.cc(469)] failed to stat report
+[0521/134428.352:ERROR:crash_report_database_win.cc(469)] failed to stat report

--- a/src/components/game/Game.js
+++ b/src/components/game/Game.js
@@ -53,8 +53,7 @@ class Game extends React.Component {
             lastTurnEndScreenDate: null, // when the last TurnEndScreen was opened
             show: false, // modal window for alert when player closes the browser unexpectedly.
             messageBox: null, // In certain situations a message box is displayed for a few seconds for information purposes.
-            previousState: null,
-            skipped: 0 //to show also the skipped cards in frontend
+            previousState: null
         };
         this.updateGame = this.updateGame.bind(this);
         this.showModal = this.showModal.bind(this);
@@ -172,7 +171,6 @@ class Game extends React.Component {
             }
             else {
                 this.setState({ guessCorrect: 'skipped' });
-                this.setState({skipped: this.state.skipped + 1});
             }
             
             this.setState({ lastTurnEndScreenDate: Date.now() });
@@ -295,7 +293,7 @@ class Game extends React.Component {
             return <GameOverview
                 gameModel={this.state.gameModel}
                 users={this.state.users}
-                skipped={this.state.skipped}
+                roundsPlayed={this.state.gameModel.round - 1}
             />;
         }
 
@@ -494,7 +492,7 @@ class Game extends React.Component {
                         </InfoLabel>
                         <Info>
                             <Orange>
-                                {this.state.skipped}
+                                {(13 - this.state.gameModel.cardStackCount) - this.state.gameModel.wordsGuessedCorrect - 2*this.state.gameModel.wordsGuessedWrong}
                             </Orange>
                         </Info>
                     </GameInfo>

--- a/src/components/game/Game.js
+++ b/src/components/game/Game.js
@@ -53,7 +53,8 @@ class Game extends React.Component {
             lastTurnEndScreenDate: null, // when the last TurnEndScreen was opened
             show: false, // modal window for alert when player closes the browser unexpectedly.
             messageBox: null, // In certain situations a message box is displayed for a few seconds for information purposes.
-            previousState: null
+            previousState: null,
+            skipped: 0 //to show also the skipped cards in frontend
         };
         this.updateGame = this.updateGame.bind(this);
         this.showModal = this.showModal.bind(this);
@@ -171,6 +172,7 @@ class Game extends React.Component {
             }
             else {
                 this.setState({ guessCorrect: 'skipped' });
+                this.setState({skipped: this.state.skipped + 1});
             }
             
             this.setState({ lastTurnEndScreenDate: Date.now() });
@@ -293,6 +295,7 @@ class Game extends React.Component {
             return <GameOverview
                 gameModel={this.state.gameModel}
                 users={this.state.users}
+                skipped={this.state.skipped}
             />;
         }
 
@@ -484,6 +487,14 @@ class Game extends React.Component {
                         <Info>
                             <Orange>
                                 {this.state.gameModel.wordsGuessedWrong}
+                            </Orange>
+                        </Info>
+                        <InfoLabel>
+                            <Orange>Skipped</Orange>
+                        </InfoLabel>
+                        <Info>
+                            <Orange>
+                                {this.state.skipped}
                             </Orange>
                         </Info>
                     </GameInfo>

--- a/src/components/game/gameEnd/GameOverview.js
+++ b/src/components/game/gameEnd/GameOverview.js
@@ -82,7 +82,7 @@ class GameOverview extends React.Component {
                         return <UserStats user={user} gameStats={this.state.gameStats} />
                       })}
                   </IndividualStatsContainer>
-                  <TeamStats gameStats={this.state.gameStats} skipped={this.props.skipped} />
+                  <TeamStats gameStats={this.state.gameStats} roundsPlayed={this.props.roundsPlayed}/>
               </CenterContainer>
           </BaseContainer>
         );

--- a/src/components/game/gameEnd/GameOverview.js
+++ b/src/components/game/gameEnd/GameOverview.js
@@ -82,7 +82,7 @@ class GameOverview extends React.Component {
                         return <UserStats user={user} gameStats={this.state.gameStats} />
                       })}
                   </IndividualStatsContainer>
-                  <TeamStats gameStats={this.state.gameStats} />
+                  <TeamStats gameStats={this.state.gameStats} skipped={this.props.skipped} />
               </CenterContainer>
           </BaseContainer>
         );

--- a/src/components/game/gameEnd/TeamStats.js
+++ b/src/components/game/gameEnd/TeamStats.js
@@ -10,8 +10,13 @@ export class TeamStats extends React.Component{
         super(props);
     }
 
-    // TODO: Get actual time and skipped cards.
     render() {
+        let skippedCount = 13 - this.props.gameStats.wordsGuessedCorrect - 2*this.props.gameStats.wordsGuessedWrong;
+        if (13 - this.props.gameStats.wordsGuessedWrong !== this.props.roundsPlayed) {
+            // last word was wrong -> -1 words left -> add 1 to skippedCount
+            skippedCount = 13 - this.props.gameStats.wordsGuessedCorrect - 2*this.props.gameStats.wordsGuessedWrong + 1;
+        }
+
         return (
             <React.Fragment>
             <StatsRow>
@@ -46,7 +51,7 @@ export class TeamStats extends React.Component{
                 </Label>
                 <Label style={{background: 'white'}}>
                     <Blue style={{letterSpacing: '0.1em'}}>
-                        {this.props.skipped}
+                        {skippedCount}
                     </Blue>
                 </Label>
             </StatsRow>

--- a/src/components/game/gameEnd/TeamStats.js
+++ b/src/components/game/gameEnd/TeamStats.js
@@ -46,7 +46,7 @@ export class TeamStats extends React.Component{
                 </Label>
                 <Label style={{background: 'white'}}>
                     <Blue style={{letterSpacing: '0.1em'}}>
-                        {13 - this.props.gameStats.wordsGuessedCorrect - this.props.gameStats.wordsGuessedWrong}
+                        {this.props.skipped}
                     </Blue>
                 </Label>
             </StatsRow>


### PR DESCRIPTION
I added a state "skipped" which counts the skipped words and show it in the game info. Also I found a small error in the game stats. Because we do not play 13 round (if a guess is wrong two cards are taken away) the skipped words is not 13 - correct - wrong. So I just give them the state of skipped words from the game to show the right number of skipped words.